### PR TITLE
Compatibility with PHP 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,17 @@
 name: CI
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
-  checks:
+  phpstan:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 7.4
+          - 8.0
+          - 8.1
 
     steps:
       - name: Checkout
@@ -13,9 +20,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring
-          coverage: xdebug
 
       - name: Get composer cache directory
         id: composercache
@@ -31,18 +37,58 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist
 
-      - name: Run phpstan
+      - name: Run PHPStan
         run: composer phpstan
 
-      - name: Run code-sniffer
-        run: composer phpcs
 
-  tests:
+  phpcs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        php-version: [ '7.4' ]
+        php-version:
+          - 7.4
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring
+
+      - name: Get composer cache directory
+        id: composercache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist
+
+      - name: Run PHP CodeSniffer
+        run: composer phpcs
+
+
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version:
+          - 7.4
+          - 8.0
+          - 8.1
+        composer-arg:
+          - install
+          - update --prefer-lowest
 
     steps:
       - name: Checkout
@@ -67,8 +113,7 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
+        run: composer ${{ matrix.composer-arg }} --prefer-dist
 
-      - name: Run phpunit
+      - name: Run PHPUnit
         run: composer phpunit
-

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "brandembassy/datetime-factory": "dev-php-8-0 as 1.2.0",
+        "brandembassy/datetime-factory": "^1.0",
         "nette/utils": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "roave/security-advisories": "dev-master"
     },
     "scripts": {
-        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src",
-        "phpcbf": "./vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src",
+        "phpcs": "vendor/bin/phpcs --standard=BrandEmbassyCodingStandard src --runtime-set php_version 70400",
+        "phpcbf": "./vendor/bin/phpcbf --standard=BrandEmbassyCodingStandard src --runtime-set php_version 70400",
         "phpstan": "./vendor/bin/phpstan analyse -c phpstan.neon src",
         "phpunit": "./vendor/bin/phpunit src --no-coverage",
         "phpunit-cc": "./vendor/bin/phpunit src",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=7.4",
-        "brandembassy/datetime-factory": "^1.0",
+        "brandembassy/datetime-factory": "dev-php-8-0 as 1.2.0",
         "nette/utils": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     "prefer-stable": true,
     "config": {
         "sort-packages": true,
+        "lock": false,
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
         }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/AmountOfTime/AmountOfTime.php
+++ b/src/AmountOfTime/AmountOfTime.php
@@ -5,7 +5,10 @@ namespace BrandEmbassy\DateTime\AmountOfTime;
 use InvalidArgumentException;
 use function floor;
 
-final class AmountOfTime
+/**
+ * @final
+ */
+class AmountOfTime
 {
     private const SECOND_IN_MILLISECOND = 1000;
 

--- a/src/AmountOfTime/AmountOfTimeTest.php
+++ b/src/AmountOfTime/AmountOfTimeTest.php
@@ -5,7 +5,10 @@ namespace BrandEmbassy\DateTime\AmountOfTime;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
-final class AmountOfTimeTest extends TestCase
+/**
+ * @final
+ */
+class AmountOfTimeTest extends TestCase
 {
     /**
      * @dataProvider millisecondsProvider

--- a/src/AmountOfTime/TimeInSeconds.php
+++ b/src/AmountOfTime/TimeInSeconds.php
@@ -5,7 +5,10 @@ namespace BrandEmbassy\DateTime\AmountOfTime;
 use Nette\StaticClass;
 use Nette\Utils\DateTime;
 
-final class TimeInSeconds
+/**
+ * @final
+ */
+class TimeInSeconds
 {
     use StaticClass;
 

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -9,7 +9,10 @@ use DateTimeZone;
 use function assert;
 use function method_exists;
 
-final class DateTimeFormatter
+/**
+ * @final
+ */
+class DateTimeFormatter
 {
     public static function formatAs(DateTimeInterface $dateTime, string $format): string
     {

--- a/src/DateTimeFormatterTest.php
+++ b/src/DateTimeFormatterTest.php
@@ -9,7 +9,10 @@ use DateTimeZone;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
-final class DateTimeFormatterTest extends TestCase
+/**
+ * @final
+ */
+class DateTimeFormatterTest extends TestCase
 {
     private const DATETIME_WITHOUT_MILLISECONDS = '2017-05-10T12:13:14+02:00';
     private const DATETIME_WITH_MILLISECONDS = '2017-05-10T12:13:14.000+02:00';
@@ -47,7 +50,7 @@ final class DateTimeFormatterTest extends TestCase
         $formattedDateTime = DateTimeFormatter::formatInTimezoneAs(
             $dateTime,
             new DateTimeZone('UTC'),
-            DateTime::ATOM
+            DateTime::ATOM,
         );
 
         Assert::assertSame($expectedUtcFormat, $formattedDateTime);
@@ -108,7 +111,7 @@ final class DateTimeFormatterTest extends TestCase
         $formattedDateTime = DateTimeFormatter::formatTimestampInTimezoneAs(
             1496237560,
             new DateTimeZone('Europe/Prague'),
-            DateTime::ATOM
+            DateTime::ATOM,
         );
 
         Assert::assertSame('2017-05-31T15:32:40+02:00', $formattedDateTime);
@@ -119,7 +122,7 @@ final class DateTimeFormatterTest extends TestCase
     {
         $formattedDateTime = DateTimeFormatter::formatTimestampInTimezone(
             1496237560,
-            new DateTimeZone('Europe/Prague')
+            new DateTimeZone('Europe/Prague'),
         );
 
         Assert::assertSame('2017-05-31T15:32:40+02:00', $formattedDateTime);
@@ -130,7 +133,7 @@ final class DateTimeFormatterTest extends TestCase
     {
         $formattedDateTime = DateTimeFormatter::formatTimestampWithMillisecondsInTimezone(
             1496237560456,
-            new DateTimeZone('Europe/Prague')
+            new DateTimeZone('Europe/Prague'),
         );
 
         Assert::assertSame('2017-05-31T15:32:40.456+02:00', $formattedDateTime);

--- a/src/DateTimeFromString.php
+++ b/src/DateTimeFromString.php
@@ -10,7 +10,10 @@ use DateTimeZone;
 use function assert;
 use function is_array;
 
-final class DateTimeFromString
+/**
+ * @final
+ */
+class DateTimeFromString
 {
     /**
      * @throws InvalidDateTimeStringException
@@ -36,7 +39,7 @@ final class DateTimeFromString
     {
         $format = Rfc3339ExtendedFormat::getInputFormat();
         $dateTimeStringInRfc3339ExtendedString = NanosecondsToMicrosecondsFormatHelper::normalizeInputIfNeeded(
-            $dateTimeStringInRfc3339ExtendedString
+            $dateTimeStringInRfc3339ExtendedString,
         );
 
         return self::createFromFormat($format, $dateTimeStringInRfc3339ExtendedString);
@@ -81,7 +84,7 @@ final class DateTimeFromString
             throw InvalidDateTimeStringException::byValidationErrors(
                 $originalDateTimeString,
                 $lastErrors['errors'],
-                $lastErrors['warnings']
+                $lastErrors['warnings'],
             );
         }
     }

--- a/src/DateTimeFromStringTest.php
+++ b/src/DateTimeFromStringTest.php
@@ -9,7 +9,10 @@ use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use function sprintf;
 
-final class DateTimeFromStringTest extends TestCase
+/**
+ * @final
+ */
+class DateTimeFromStringTest extends TestCase
 {
     /**
      * @dataProvider dateTimeInFormatProvider
@@ -160,7 +163,7 @@ final class DateTimeFromStringTest extends TestCase
     {
         $this->expectException(InvalidDateTimeStringException::class);
         $this->expectExceptionMessage(
-            "Can't convert '2020-12-05T02:50:16.123+03:00' to datetime using format Y-m-d\TH:i:sP."
+            "Can't convert '2020-12-05T02:50:16.123+03:00' to datetime using format Y-m-d\TH:i:sP.",
         );
 
         DateTimeFromString::create('2020-12-05T02:50:16.123+03:00');
@@ -173,8 +176,8 @@ final class DateTimeFromStringTest extends TestCase
         $this->expectExceptionMessage(
             sprintf(
                 "Can't convert '2020-12-05T02:50:16+03:00' to datetime using format %s.",
-                Rfc3339ExtendedFormat::getInputFormat()
-            )
+                Rfc3339ExtendedFormat::getInputFormat(),
+            ),
         );
 
         DateTimeFromString::createWithMilliseconds('2020-12-05T02:50:16+03:00');

--- a/src/DateTimeFromTimestamp.php
+++ b/src/DateTimeFromTimestamp.php
@@ -6,7 +6,10 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use function sprintf;
 
-final class DateTimeFromTimestamp
+/**
+ * @final
+ */
+class DateTimeFromTimestamp
 {
     /**
      * @throws InvalidArgumentException

--- a/src/DateTimeModifier.php
+++ b/src/DateTimeModifier.php
@@ -6,7 +6,10 @@ use DateTimeImmutable;
 use DateTimeZone;
 use Nette\StaticClass;
 
-final class DateTimeModifier
+/**
+ * @final
+ */
+class DateTimeModifier
 {
     use StaticClass;
 

--- a/src/DateTimeModifierTest.php
+++ b/src/DateTimeModifierTest.php
@@ -6,7 +6,10 @@ use DateTimeZone;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
-final class DateTimeModifierTest extends TestCase
+/**
+ * @final
+ */
+class DateTimeModifierTest extends TestCase
 {
     /**
      * @dataProvider getBeginningOfTheDayDataProvider
@@ -18,7 +21,7 @@ final class DateTimeModifierTest extends TestCase
 
         Assert::assertSame(
             DateTimeFormatter::format($expectedDateTime),
-            DateTimeFormatter::format(DateTimeModifier::getBeginningOfTheDay($originDateTime))
+            DateTimeFormatter::format(DateTimeModifier::getBeginningOfTheDay($originDateTime)),
         );
     }
 
@@ -55,8 +58,8 @@ final class DateTimeModifierTest extends TestCase
         Assert::assertSame(
             DateTimeFormatter::format($expectedDateTime),
             DateTimeFormatter::format(
-                DateTimeModifier::getBeginningOfTheDayInTimezone($originDateTime, $dateTimeZone)
-            )
+                DateTimeModifier::getBeginningOfTheDayInTimezone($originDateTime, $dateTimeZone),
+            ),
         );
     }
 
@@ -101,7 +104,7 @@ final class DateTimeModifierTest extends TestCase
 
         Assert::assertSame(
             DateTimeFormatter::format($expectedDateTime),
-            DateTimeFormatter::format(DateTimeModifier::getEndOfTheDay($originDateTime))
+            DateTimeFormatter::format(DateTimeModifier::getEndOfTheDay($originDateTime)),
         );
     }
 
@@ -138,8 +141,8 @@ final class DateTimeModifierTest extends TestCase
         Assert::assertSame(
             DateTimeFormatter::format($expectedDateTime),
             DateTimeFormatter::format(
-                DateTimeModifier::getEndOfTheDayInTimezone($originDateTime, $dateTimeZone)
-            )
+                DateTimeModifier::getEndOfTheDayInTimezone($originDateTime, $dateTimeZone),
+            ),
         );
     }
 

--- a/src/Doctrine/DateTimeImmutableAsTimestampDoctrineType.php
+++ b/src/Doctrine/DateTimeImmutableAsTimestampDoctrineType.php
@@ -9,7 +9,10 @@ use Doctrine\DBAL\Types\Type;
 use InvalidArgumentException;
 use function is_float;
 
-final class DateTimeImmutableAsTimestampDoctrineType extends Type
+/**
+ * @final
+ */
+class DateTimeImmutableAsTimestampDoctrineType extends Type
 {
     public const NAME = 'datetime_immutable_as_timestamp';
 

--- a/src/Format/NanosecondsToMicrosecondsFormatHelper.php
+++ b/src/Format/NanosecondsToMicrosecondsFormatHelper.php
@@ -6,7 +6,10 @@ use function array_shift;
 use function implode;
 use function preg_match;
 
-final class NanosecondsToMicrosecondsFormatHelper
+/**
+ * @final
+ */
+class NanosecondsToMicrosecondsFormatHelper
 {
     private const MICROSECONDS_AND_TIMEZONE_PATTERN = '/^(^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d{6})\d*(Z|(?:\+|\-)[0,1]\d:00)$/';
 

--- a/src/Format/NanosecondsToMicrosecondsFormatHelperTest.php
+++ b/src/Format/NanosecondsToMicrosecondsFormatHelperTest.php
@@ -5,7 +5,10 @@ namespace BrandEmbassy\DateTime\Format;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 
-final class NanosecondsToMicrosecondsFormatHelperTest extends TestCase
+/**
+ * @final
+ */
+class NanosecondsToMicrosecondsFormatHelperTest extends TestCase
 {
     /**
      * @dataProvider dateTimeAsStringProvider

--- a/src/Format/Rfc3339ExtendedFormat.php
+++ b/src/Format/Rfc3339ExtendedFormat.php
@@ -4,7 +4,10 @@ namespace BrandEmbassy\DateTime\Format;
 
 use DateTime;
 
-final class Rfc3339ExtendedFormat
+/**
+ * @final
+ */
+class Rfc3339ExtendedFormat
 {
     public static function getOutputFormat(): string
     {

--- a/src/InvalidDateTimeStringException.php
+++ b/src/InvalidDateTimeStringException.php
@@ -6,7 +6,10 @@ use InvalidArgumentException;
 use function array_values;
 use function sprintf;
 
-final class InvalidDateTimeStringException extends InvalidArgumentException
+/**
+ * @final
+ */
+class InvalidDateTimeStringException extends InvalidArgumentException
 {
     /**
      * @var string[]
@@ -26,7 +29,7 @@ final class InvalidDateTimeStringException extends InvalidArgumentException
         $message = sprintf(
             "Can't convert '%s' to datetime using format %s.",
             $dateTimeStringInNotRecognizedFormat,
-            $requiredFormat
+            $requiredFormat,
         );
 
         return new self($message);

--- a/src/StringFromNow.php
+++ b/src/StringFromNow.php
@@ -4,7 +4,10 @@ namespace BrandEmbassy\DateTime;
 
 use DateTimeZone;
 
-final class StringFromNow
+/**
+ * @final
+ */
+class StringFromNow
 {
     private DateTimeImmutableFactory $dateTimeImmutableFactory;
 


### PR DESCRIPTION
This PR allows for PHP 8.0, also bumps coding standard version and extends GitHub Actions workflow for easier maintenance.
Builds on https://github.com/BrandEmbassy/datetime-factory/pull/4

I suggest releasing this as a MINOR version (3.3.0).